### PR TITLE
feat: prefix parse

### DIFF
--- a/includes/parser/CommandParser.hpp
+++ b/includes/parser/CommandParser.hpp
@@ -46,7 +46,7 @@ class CommandParser {
         static IParser* getParser(std::string command);
     
     public:
-        static ACommand* parse(const std::string& command);
+        static ACommand* parse(const std::string& command, const User &client);
 };
 
 #endif

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -283,7 +283,7 @@ void Server::handleExistingConnection(int clientFd) {
         User &client = getUserByFd(clientFd);
 
         try {
-            ACommand* command = CommandParser::parse(message);
+            ACommand* command = CommandParser::parse(message, client);
 
             if (!command)
                 continue;

--- a/src/parser/CommandParser.cpp
+++ b/src/parser/CommandParser.cpp
@@ -4,11 +4,21 @@
  * Parses the command.
  * 
  * @param input The command to parse.
+ * @param client The client that sent the command.
  * 
  * @return The parsed command.
  */
-ACommand* CommandParser::parse(const std::string& input) {
+ACommand* CommandParser::parse(const std::string& input, const User &client) {
     std::vector<std::string> tokens = CommandParser::tokenize(input);
+    if (tokens.size >= 2 && tokens[0][0] == ':')
+    {
+        std::string nickname = client.getNickname();
+        if (tokens[0].substr(1) != nickname && tokens[0] != USER_ID(nickname, client.getUsername(), client.getHostname())) {
+            // throw new IRCException();
+        }
+        tokens.erase(tokens.begin());
+    }
+
     IParser *parser = CommandParser::getParser(tokens[0]);
     if (!parser)
         return NULL;

--- a/src/parser/CommandParser.cpp
+++ b/src/parser/CommandParser.cpp
@@ -10,7 +10,7 @@
  */
 ACommand* CommandParser::parse(const std::string& input, const User &client) {
     std::vector<std::string> tokens = CommandParser::tokenize(input);
-    if (tokens.size >= 2 && tokens[0][0] == ':')
+    if (tokens.size() >= 2 && tokens[0][0] == ':')
     {
         std::string nickname = client.getNickname();
         if (tokens[0].substr(1) != nickname && tokens[0] != USER_ID(nickname, client.getUsername(), client.getHostname())) {


### PR DESCRIPTION
fasilito el parseo en verdad.

He visto que el prefijo puede tener dos formatos: simple y completo

Simple: :nickname
Completo :nickname!username@hostname

El prefijo debe ser igual a los datos del usuario que manda el comando siempre, pero el valor no se usa para nada